### PR TITLE
Change: rename BlossomLeaf to BlossomIO

### DIFF
--- a/tests/functional_tests/test_blossom.cpp
+++ b/tests/functional_tests/test_blossom.cpp
@@ -41,15 +41,15 @@ TestBlossom::TestBlossom(Session_Test* sessionTest)
 }
 
 bool
-TestBlossom::runTask(Sakura::BlossomLeaf &blossomLeaf,
+TestBlossom::runTask(Sakura::BlossomIO &blossomIO,
                      const DataMap &,
                      Sakura::BlossomStatus &status,
                      ErrorContainer &)
 {
     LOG_DEBUG("TestBlossom");
-    const int value = blossomLeaf.input.get("input").getInt();
+    const int value = blossomIO.input.get("input").getInt();
     m_sessionTest->compare(value, 42);
-    blossomLeaf.output.insert("output", 42);
+    blossomIO.output.insert("output", 42);
 
     status.statusCode = OK_RTYPE;
     return true;

--- a/tests/functional_tests/test_blossom.h
+++ b/tests/functional_tests/test_blossom.h
@@ -38,7 +38,7 @@ public:
     TestBlossom(Session_Test* sessionTest);
 
 protected:
-    bool runTask(Sakura::BlossomLeaf &blossomLeaf,
+    bool runTask(Sakura::BlossomIO &blossomIO,
                  const DataMap &context,
                  Sakura::BlossomStatus &status,
                  ErrorContainer &);


### PR DESCRIPTION
## Description

Change: rename BlossomLeaf to BlossomIO

## Related Issues

- https://github.com/kitsudaiki/HanamiAI/issues/13

## How it was tested

- ci-pipeline